### PR TITLE
allow api.band.us, it is 'BAND' biggest group message app in korea

### DIFF
--- a/hosts
+++ b/hosts
@@ -2672,7 +2672,6 @@
 0.0.0.0 w.x.baidu.com
 0.0.0.0 baidustatic.com
 0.0.0.0 ubmcmm.baidustatic.com
-0.0.0.0 api.band.us
 0.0.0.0 bango.net
 0.0.0.0 bannerads.co.in
 0.0.0.0 bannerbank.ru

--- a/list3
+++ b/list3
@@ -491,7 +491,6 @@
 127.0.0.1 api.ateam-ad.jp
 127.0.0.1 api.attentivemobile.com
 127.0.0.1 api.attribution.io
-127.0.0.1 api.band.us
 127.0.0.1 api.beaconsinspace.com
 127.0.0.1 api.beaconstreetservices.com
 127.0.0.1 api.bluecore.com


### PR DESCRIPTION
api.band.us is 'BAND' REST API domain, and it is the biggest group message app in Korea.
so many Korean people suffering problems.

I wish you apply this PR. thank you.