### PR TITLE
Remove Gitter Sidecar from blocked hosts

### DIFF
--- a/hosts
+++ b/hosts
@@ -4987,7 +4987,6 @@
 0.0.0.0 stats.gioneemobile.net
 0.0.0.0 cdn-prod-defaulting-gamedev-ads.gismart.xyz
 0.0.0.0 prod-defaulting-subscriptiontool.gismart.xyz
-0.0.0.0 sidecar.gitter.im
 0.0.0.0 cdn.gladly.com
 0.0.0.0 production1.gladly.com
 0.0.0.0 us-1.gladly.com


### PR DESCRIPTION
Remove Gitter Sidecar from blocked hosts

Gitter Sidecar was also from adaway repo in https://github.com/AdAway/adaway.github.io/pull/85